### PR TITLE
Make aemm aar have highest dependency order

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -31,6 +31,17 @@ repositories {
 
 apply plugin: 'com.android.application'
 
+apply from: 'dependencies.gradle'
+
+dependencies {
+	compile (name:'aemm-lib-release', ext:'aar')
+
+	compile fileTree(dir: 'libs', include: ['*.jar'], excludes:['adobeMobileLibrary-*.jar'])
+
+	// SUB-PROJECT DEPENDENCIES START
+	// SUB-PROJECT DEPENDENCIES END
+}
+
 // PLUGIN GRADLE EXTENSIONS START
 // PLUGIN GRADLE EXTENSIONS END
 
@@ -75,15 +86,4 @@ android {
 			minifyEnabled true
 		}
 	}
-}
-
-apply from: 'dependencies.gradle'
-
-dependencies {
-	compile (name:'aemm-lib-release', ext:'aar')
-
-	compile fileTree(dir: 'libs', include: ['*.jar'], excludes:['adobeMobileLibrary-*.jar'])
-
-	// SUB-PROJECT DEPENDENCIES START
-	// SUB-PROJECT DEPENDENCIES END
 }


### PR DESCRIPTION
We ran into issues with other aars' resources overwriting our own.  This fix will ensure all plugin scripts and dependencies have a lower priority than our own aar.
